### PR TITLE
Fix broken syntax highlighting library

### DIFF
--- a/lout/page.html
+++ b/lout/page.html
@@ -157,7 +157,7 @@
   </div>
 
 
-<script src="https://google-code-prettify.googlecode.com/svn/loader/run_prettify.js?lang=hs&skin=default"></script>
+  <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js?lang=hs&amp;skin=sunburst"></script>
 
     <!-- Bootstrap core JavaScript
     ================================================== -->


### PR DESCRIPTION
Hi! I noticed that the CDN for Google's [prettify syntax highlighter](https://github.com/googlearchive/code-prettify)  was no longer available and just returned a HTTP error on each request.

I replaced the URL in the template with a valid one from *jsdelivr*. For some reason the `default` theme still seems to cause issues so I also switched to the dark `sunburst` theme. 

However, it might be a good idea to switch to another solution entirely (like [highlightjs](https://highlightjs.org/)).